### PR TITLE
fix(web): broken UI after antd upgrade

### DIFF
--- a/web/src/components/molecules/Common/Header/Header.tsx
+++ b/web/src/components/molecules/Common/Header/Header.tsx
@@ -95,20 +95,20 @@ const Header: React.FC<Props> = ({ username, lang, isLoggedIn, login, logout, on
                   </div>
                 </Tooltip>
               )}
-              <Dropdown menu={langMenu} trigger={["click"]} placement="bottom">
+              <StyledDropdown menu={langMenu} trigger={["click"]} placement="bottom">
                 <DropdownContents>
                   <Lang>{DisplayLang[lang]}</Lang>
                   <StyledIcon icon="downFilled" />
                 </DropdownContents>
-              </Dropdown>
+              </StyledDropdown>
               {isLoggedIn ? (
-                <Dropdown menu={userMenu} trigger={["click"]} placement="bottom">
+                <StyledDropdown menu={userMenu} trigger={["click"]} placement="bottom">
                   <DropdownContents>
                     <NameIcon>{username?.charAt(0).toUpperCase()}</NameIcon>
                     <UserName>{username}</UserName>
                     <StyledIcon icon="downFilled" />
                   </DropdownContents>
-                </Dropdown>
+                </StyledDropdown>
               ) : (
                 <LoginWrapper onClick={login}>{t("Log in")}</LoginWrapper>
               )}
@@ -131,6 +131,10 @@ const Title = styled.h1`
   color: #df3013;
   font-size: 14px;
   cursor: pointer;
+`;
+
+const StyledDropdown = styled(Dropdown)`
+  height: 40px;
 `;
 
 const DropdownContents = styled.div`

--- a/web/src/components/molecules/Common/Header/Header.tsx
+++ b/web/src/components/molecules/Common/Header/Header.tsx
@@ -134,7 +134,7 @@ const Title = styled.h1`
 `;
 
 const StyledDropdown = styled(Dropdown)`
-  height: 40px;
+  height: 48px;
 `;
 
 const DropdownContents = styled.div`

--- a/web/src/components/molecules/PluginsList.tsx
+++ b/web/src/components/molecules/PluginsList.tsx
@@ -1,5 +1,6 @@
 import Space from "@marketplace/components/atoms/Space";
 import PluginsListCard from "@marketplace/components/molecules/PluginsListCard";
+import { styled } from "@marketplace/theme";
 
 export type Props = {
   plugins?: Plugin[];
@@ -21,7 +22,7 @@ export type Plugin = {
 
 const PluginsList: React.FC<Props> = ({ plugins, loading, onPluginSelect }) => {
   return (
-    <Space size={[30, 18]} wrap>
+    <Wrapper size={[30, 18]} wrap>
       {plugins
         ? plugins.map((plugin: Plugin) => {
             return (
@@ -39,8 +40,12 @@ const PluginsList: React.FC<Props> = ({ plugins, loading, onPluginSelect }) => {
             );
           })
         : null}
-    </Space>
+    </Wrapper>
   );
 };
+
+const Wrapper = styled(Space)`
+  margin-bottom: 24px;
+`;
 
 export default PluginsList;


### PR DESCRIPTION
## What I've done
- style: header dropdowns are dropping down directly under the text.
- style: the pagination stepper is clipping the plugin card.