### PR TITLE
ci: migrate to GitHub Apps from PAT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,10 +59,15 @@ jobs:
       # ARTIFACTS_SERVER: server/dist #TODO: fix here
       ARTIFACTS_WEB: reearth-marketplace-web_${{ needs.info.outputs.name }}.tar.gz
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - name: get latest web artifact
         uses: dawidd6/action-download-artifact@v2
         with:
-          github_token: ${{ secrets.GPT }}
+          github_token: ${{ steps.app-token.outputs.token }}
           workflow: ci.yml
           workflow_conclusion: success
           branch: ${{ github.event.workflow_run.head_branch }}
@@ -112,6 +117,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -148,7 +158,7 @@ jobs:
       - name: Download web arfiacts
         uses: dawidd6/action-download-artifact@v2
         with:
-          github_token: ${{ secrets.GPT }}
+          github_token: ${{ steps.app-token.outputs.token }}
           workflow: ci.yml
           workflow_conclusion: success
           branch: ${{ github.event.workflow_run.head_branch }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,10 +15,15 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion != 'failure' && github.event.repository.full_name == 'reearth/reearth-marketplace' && github.event.workflow_run.head_branch == 'main'
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - name: get latest web artifact
         uses: dawidd6/action-download-artifact@v2
         with:
-          github_token: ${{ secrets.GPT }}
+          github_token: ${{ steps.app-token.outputs.token }}
           workflow: ci.yml
           workflow_conclusion: success
           branch: main
@@ -42,6 +47,11 @@ jobs:
       id-token: write
       packages: read
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - uses: google-github-actions/auth@v0
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
@@ -55,7 +65,7 @@ jobs:
       - name: Download server arfiacts
         uses: dawidd6/action-download-artifact@v2
         with:
-          github_token: ${{ secrets.GPT }}
+          github_token: ${{ steps.app-token.outputs.token }}
           workflow: build.yml
           workflow_conclusion: success
           branch: main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,17 +18,22 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/release'
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - name: git config
         env:
-          GPT_USER: ${{ secrets.GPT_USER }}
+          GH_APP_USER: ${{ vars.GH_APP_USER }}
         run: |
-          git config --global user.name $GPT_USER
+          git config --global user.name $GH_APP_USER
           git config --global pull.rebase false
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.GPT }}
+          token: ${{ steps.app-token.outputs.token }}
       - id: changelog
         name: Generate CHANGELOG
         uses: reearth/changelog-action@main

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -8,16 +8,21 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - name: git config
         env:
-          GPT_USER: ${{ secrets.GPT_USER }}
+          GH_APP_USER: ${{ vars.GH_APP_USER }}
         run: |
-          git config --global user.name $GPT_USER
+          git config --global user.name $GH_APP_USER
           git config --global pull.rebase false
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.GPT }}
+          token: ${{ steps.app-token.outputs.token }}
       - name: Checkout release branch
         run: git switch release || git switch -c release
       - name: Merge main branch to release branch


### PR DESCRIPTION
## What I've done

For automation, it's bad practice to use the static GitHub Personal Access Token (PAT).

Instead, using the short-living token generated by the GitHub App is more secure, and we can have more control over our access to the GitHub API. Also, GitHub Apps are way better than managing PAT, which brings security and management improvements.

## What I haven't done


## How I tested


## Which point I want you to review particularly


## Notes
