### PR TITLE
ci: migrate to GAR from GCR

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ env:
   REEARTH_MARKETPLACE_URL: marketplace.test.reearth.dev
   REEARTH_API: "https://api.marketplace.test.reearth.dev/api"
   GCS_DEST: gs://marketplace.test.reearth.dev
-  IMAGE_GCP: us.gcr.io/reearth-oss/reearth-marketplace:nightly
+  IMAGE_GCP: us-central1-docker.pkg.dev/reearth-oss/reearth/reearth-marketplace:nightly
   GCP_REGION: us-central1
 jobs:
   deploy_web:
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
       - name: Configure docker
-        run: gcloud auth configure-docker --quiet
+        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
       - name: Download server arfiacts
         uses: dawidd6/action-download-artifact@v2
         with:


### PR DESCRIPTION
## What I've done

Because the GCR (Google Container Registry) will be decommissioned.

* [Transition from Container Registry, Google Cloud](https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr) 

> Container Registry is deprecated and scheduled for shutdown. After May 15, 2024, Artifact Registry will host images for the gcr.io domain in Google Cloud projects without previous Container Registry usage

## What I haven't done


## How I tested


## Which point I want you to review particularly


## Notes

Re:Earth Visualizer version: https://github.com/reearth/reearth-visualizer/pull/1018
