### PR TITLE
fix(ci): use upload-artifact v4 for docker step in build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,7 +183,7 @@ jobs:
       - name: Save docker image
         run: docker save ${{ steps.options.outputs.tags }} | gzip > reearth-marketplace.tar.gz
       - name: Save imaged to artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         # env:
         #   TAG: ${{ needs.info.outputs.tag_short }}
         #   NAME: ${{ needs.info.outputs.name }}


### PR DESCRIPTION
## What I've done
changed the upload-artifact version in the build.yml file as current version is deprecated hence stopping the docker build step and deployment I believe
https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

<img width="912" alt="Screenshot 2024-10-18 at 5 04 05 AM" src="https://github.com/user-attachments/assets/23a5a88d-d3d2-4978-a5ef-6c7c0ceb7e3e">
 

## What I haven't done


## How I tested
Not sure of other possible ways to test except creating a PR but if there is another way to test that would help.

## Which point I want you to review particularly


## Notes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated workflow configuration for better control flow and job execution conditions.
	- Enhanced handling of tags and branch names during workflow execution.
	- Upgraded artifact handling by changing the action version for uploading artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->