### PR TITLE
fix(web): amend tab styles on homepage

### DIFF
--- a/web/src/components/molecules/TopPage/TopPageContents.tsx
+++ b/web/src/components/molecules/TopPage/TopPageContents.tsx
@@ -63,7 +63,7 @@ const TopPageContents: React.FC<Props> = ({
   return (
     <div>
       {!version && (
-        <TabsWrapper>
+        <TabsWrapper className="homepage-tabs">
           <Tabs
             defaultActiveKey="0"
             items={tabs}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -25,6 +25,9 @@ p {
 
 .ant-tabs .ant-tabs-tab {
   color: rgba(255, 255, 255, 0.8);
+  font-size: 16px !important;
+  line-height: 22px;
+  font-weight: 500;
 }
 
 .ant-tabs .ant-tabs-ink-bar {
@@ -41,4 +44,8 @@ p {
 
 .ant-tabs-nav::before {
   border-bottom: none !important;
+}
+
+.ant-tabs-nav {
+  margin-bottom: 2px !important;
 }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -18,34 +18,36 @@ p {
   margin: 0;
 }
 
-.ant-tabs-ink-bar {
-  height: 5px;
-  color: #ffffff;
-}
-
-.ant-tabs .ant-tabs-tab {
-  color: rgba(255, 255, 255, 0.8);
-  font-size: 16px !important;
-  line-height: 22px;
-  font-weight: 500;
-}
-
-.ant-tabs .ant-tabs-ink-bar {
-  background: #ffffff !important;
-}
-
-.ant-tabs-tab:hover {
-  color: #ffffff !important;
-}
-
-.ant-tabs-tab.ant-tabs-tab-active .ant-tabs-tab-btn {
-  color: #ffffff !important;
-}
-
-.ant-tabs-nav::before {
-  border-bottom: none !important;
-}
-
-.ant-tabs-nav {
-  margin-bottom: 2px !important;
+.homepage-tabs {
+  .ant-tabs-ink-bar {
+    height: 5px;
+    color: #ffffff;
+  }
+  
+  .ant-tabs .ant-tabs-tab {
+    color: rgba(255, 255, 255, 0.8);
+    font-size: 16px !important;
+    line-height: 22px;
+    font-weight: 500;
+  }
+  
+  .ant-tabs .ant-tabs-ink-bar {
+    background: #ffffff !important;
+  }
+  
+  .ant-tabs-tab:hover {
+    color: #ffffff !important;
+  }
+  
+  .ant-tabs-tab.ant-tabs-tab-active .ant-tabs-tab-btn {
+    color: #ffffff !important;
+  }
+  
+  .ant-tabs-nav::before {
+    border-bottom: none !important;
+  }
+  
+  .ant-tabs-nav {
+    margin-bottom: 2px !important;
+  }
 }


### PR DESCRIPTION
## What I've done
Reduced the margin below the tabs and changed the font size of the tabs to match design.

screenshot of design
<img width="177" alt="Screenshot 2024-10-29 at 8 51 00 AM" src="https://github.com/user-attachments/assets/e4f5ee4b-8b47-442f-afa2-03cf0f521bd6">
screenshot of implementation
<img width="374" alt="Screenshot 2024-10-29 at 8 50 44 AM" src="https://github.com/user-attachments/assets/bccd2d06-6c2c-4678-bdbd-17a7fcfe956f">
 [Link to Figma design](https://www.figma.com/design/phqYf7l4LDJzCpvM3cLcRN/MarketPlace-UI-1.0?node-id=1701-17400&node-type=canvas&m=dev)

## What I haven't done


## How I tested


## Which point I want you to review particularly


## Notes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Introduced a new `.homepage-tabs` class to encapsulate styles for tab components, enhancing organization and readability.
	- Updated styles for tab components, including font size, line height, and font weight for improved visual clarity.
	- Adjusted margin for tab navigation to enhance spacing and presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->