### PR TITLE
fix(web): update language setting in extension based on client setting

### DIFF
--- a/web/src/components/pages/extensions/sharedProviders.tsx
+++ b/web/src/components/pages/extensions/sharedProviders.tsx
@@ -10,7 +10,7 @@ import "@marketplace/index.css";
 
 export default function SharedProviders({
   theme,
-  // lang,
+  lang,
   accessToken,
   children,
 }: {
@@ -26,7 +26,7 @@ export default function SharedProviders({
       theme={{
         algorithm: theme === "dark" ? ProviderTheme.darkAlgorithm : ProviderTheme.defaultAlgorithm,
       }}>
-      <I18nProvider>
+      <I18nProvider extensionSetLang={lang}>
         <GqlProvider accessToken={accessToken}>
           <ThemeProvider theme={theme}>{children}</ThemeProvider>
         </GqlProvider>

--- a/web/src/i18n/provider.tsx
+++ b/web/src/i18n/provider.tsx
@@ -16,7 +16,13 @@ const getBrowserLanguage = () => {
   }
 };
 
-export default function Provider({ children }: { children?: ReactNode }) {
+export default function Provider({
+  extensionSetLang,
+  children,
+}: {
+  extensionSetLang?: string;
+  children?: ReactNode;
+}) {
   const { isAuthenticated } = useAuth();
   const [currentLang, setLang] = useCurrentLang();
 
@@ -26,7 +32,8 @@ export default function Provider({ children }: { children?: ReactNode }) {
     },
     skip: !isAuthenticated,
   });
-  const locale = data?.me.lang ?? currentLang;
+
+  const locale = extensionSetLang ? extensionSetLang : data?.me.lang ?? currentLang;
 
   useEffect(() => {
     const lang = locale === "und" ? getBrowserLanguage() : locale;

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -18,36 +18,34 @@ p {
   margin: 0;
 }
 
-.homepage-tabs {
-  .ant-tabs-ink-bar {
-    height: 5px;
-    color: #ffffff;
-  }
-  
-  .ant-tabs .ant-tabs-tab {
-    color: rgba(255, 255, 255, 0.8);
-    font-size: 16px !important;
-    line-height: 22px;
-    font-weight: 500;
-  }
-  
-  .ant-tabs .ant-tabs-ink-bar {
-    background: #ffffff !important;
-  }
-  
-  .ant-tabs-tab:hover {
-    color: #ffffff !important;
-  }
-  
-  .ant-tabs-tab.ant-tabs-tab-active .ant-tabs-tab-btn {
-    color: #ffffff !important;
-  }
-  
-  .ant-tabs-nav::before {
-    border-bottom: none !important;
-  }
-  
-  .ant-tabs-nav {
-    margin-bottom: 2px !important;
-  }
+.homepage-tabs .ant-tabs-ink-bar {
+  height: 5px;
+  color: #ffffff;
+}
+
+.homepage-tabs .ant-tabs .ant-tabs-tab {
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 16px !important;
+  line-height: 22px;
+  font-weight: 500;
+}
+
+.homepage-tabs .ant-tabs .ant-tabs-ink-bar {
+  background: #ffffff !important;
+}
+
+.homepage-tabs .ant-tabs-tab:hover {
+  color: #ffffff !important;
+}
+
+.homepage-tabs .ant-tabs-tab.ant-tabs-tab-active .ant-tabs-tab-btn {
+  color: #ffffff !important;
+}
+
+.homepage-tabs .ant-tabs-nav::before {
+  border-bottom: none !important;
+}
+
+.homepage-tabs .ant-tabs-nav {
+  margin-bottom: 2px !important;
 }


### PR DESCRIPTION
## What I've done
Made use of the language prop that is received from the client ( visualizer or classic ) to set the language displayed in the extension. Also made a small refactor to the tab CSS styles

## What I haven't done


## How I tested
Tested by running visualizer and classic locally and making changes to the client's language settings and checking the language displayed in the extension.
Link to video on Visualizer: https://eukarya-inc.slack.com/archives/C06S0GZR2DC/p1732069401402799
Link to video on Classic: https://eukarya-inc.slack.com/archives/C06S0GZR2DC/p1732069347418199

## Which point I want you to review particularly


## Notes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced language support in the `SharedProviders` component for improved internationalization.
	- Added the ability to set language externally via the `extensionSetLang` prop in the `Provider` component.
  
- **Bug Fixes**
	- Restructured CSS for `.homepage-tabs` to improve specificity and maintainability without altering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->