### PR TITLE
fix: add reearthWeb filed

### DIFF
--- a/web/docker/reearth_config.json.template
+++ b/web/docker/reearth_config.json.template
@@ -5,6 +5,7 @@
   "authAudience": "${AUTH_AUDIENCE}",
   "reportUrl": "${REPORT_URL}",
   "reearthApi": "${REEARTH_API}",
+  "reearthWeb": "${REEARTH_WEB}",
   "reearthClassicWeb": "${REEARTH_CLASSIC_WEB}",
   "reearthVisualizerWeb": "${REEARTH_VISUALIZER_WEB}"
 }


### PR DESCRIPTION
## What I've done
added the `reearthWeb` field to the reearth_config as it was missing.

## What I haven't done


## How I tested


## Which point I want you to review particularly


## Notes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
	- Added a new web service configuration parameter for Reearth
	- Introduced environment variable support for web configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->