### PR TITLE
ci: authenticate to GCP using Workload Identity instead of SA key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Pack
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release'
         run: mv dist reearth-marketplace-web && tar -zcvf reearth-marketplace-web.tar.gz reearth-marketplace-web
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release'
         with:
           name: reearth-marketplace-web

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,19 +7,23 @@ on:
 env:
   REEARTH_MARKETPLACE_URL: marketplace.test.reearth.dev
   REEARTH_API: "https://api.marketplace.test.reearth.dev/api"
-  SERVER_IMAGE_GCP: us-central1-docker.pkg.dev/reearth-oss/reearth/reearth-marketplace-api:nightly
-  WEB_IMAGE_GCP: us-central1-docker.pkg.dev/reearth-oss/reearth/reearth-marketplace-web:nightly
+  SERVER_IMAGE_GCP: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/reearth/reearth-marketplace-api:nightly
+  WEB_IMAGE_GCP: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/reearth/reearth-marketplace-web:nightly
   GCP_REGION: us-central1
 jobs:
   deploy_web:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion != 'failure' && github.event.repository.full_name == 'reearth/reearth-marketplace' && github.event.workflow_run.head_branch == 'main'
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - uses: google-github-actions/auth@v0
+      - uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          service_account: ${{ secrets.GCP_SA_EMAIL }}
+          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v2
       - name: Configure docker
         run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
       - name: docker build and push
@@ -47,14 +51,12 @@ jobs:
         with:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-      - uses: google-github-actions/auth@v0
+      - uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-      #   with:
-      #     workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-      #     service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+          service_account: ${{ secrets.GCP_SA_EMAIL }}
+          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v2
       - name: Configure docker
         run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
       - name: Download server arfiacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           repo: ${{ github.repository }}
           latest: CHANGELOG_latest.md
       - name: Upload latest CHANGELOG
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: changelog-${{ steps.changelog.outputs.version }}
           path: CHANGELOG_latest.md


### PR DESCRIPTION
## What I've done
Mask GCP project-id and update authentication to use WI federation instead of static SA-key
Part of `Update and refactor CI/CD` task

## What I haven't done


## How I tested


## Which point I want you to review particularly


## Notes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded artifact handling in build and release workflows for greater reliability.
  - Enhanced deployment processes by adopting secure, secret-driven configurations and updated permission settings.
  - Streamlined continuous integration and release procedures to ensure consistent and efficient operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->