### PR TITLE
chore(server): rename reearth_marketplace mongodb db name

### DIFF
--- a/server/internal/app/repo.go
+++ b/server/internal/app/repo.go
@@ -28,7 +28,7 @@ func initReposAndGateways(ctx context.Context, conf *Config, debug bool) (*repo.
 	if err != nil {
 		log.Fatalf("repo initialization error: %+v\n", err)
 	}
-	if err := mongorepo.InitRepos(ctx, repos, client, "reearth_marketplace", mongox.IsTransactionAvailable(conf.DB)); err != nil {
+	if err := mongorepo.InitRepos(ctx, repos, client, "reearth-marketplace", mongox.IsTransactionAvailable(conf.DB)); err != nil {
 		log.Fatalf("Failed to init mongo: %+v\n", err)
 	}
 


### PR DESCRIPTION
## What I've done

- Follow up actions after db is merged to reearth-oss cluster
- Update db name from `reearth_marketplace` to `reearth-marketplace` to follow the db naming convention

## What I haven't done


## How I tested


## Which point I want you to review particularly


## Notes

- Details of new DB also has been updated in the service configuration level in our infra

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

This release includes a minor update to improve internal consistency. We adjusted the naming configuration for backend components to ensure uniform conventions across the system. No changes impact user-facing functionality, and you should experience the same reliable performance.

- **Chores**
  - Adjusted repository naming for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->