### PR TITLE
ci: add harden-runner to GitHub Actions workflows

### DIFF
--- a/.github/workflows/build_prepare.yml
+++ b/.github/workflows/build_prepare.yml
@@ -19,6 +19,10 @@ jobs:
       new_tag_short: ${{ steps.info.outputs.new_tag_short }}
       name: ${{ steps.info.outputs.name }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
       - name: checkout
         uses: actions/checkout@v4
       - name: Fetch tags

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -26,6 +26,10 @@ jobs:
     env:
       ARTIFACTS: server/dist/reearth_*.*
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build_server.yml
+++ b/.github/workflows/build_server.yml
@@ -29,6 +29,10 @@ jobs:
       run:
         working-directory: server
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@v4
       - uses: actions/create-github-app-token@v1

--- a/.github/workflows/build_web.yml
+++ b/.github/workflows/build_web.yml
@@ -28,6 +28,10 @@ jobs:
       run:
         working-directory: web
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up QEMU
@@ -83,6 +87,10 @@ jobs:
     env:
       NODE_OPTIONS: "--max-old-space-size=8192"
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
@@ -119,6 +127,10 @@ jobs:
     env:
       ARTIFACT: reearth-web_${{ inputs.name }}.tar.gz
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
       - uses: actions/create-github-app-token@v1
         id: app-token
         with:
@@ -147,6 +159,10 @@ jobs:
     env:
       ARTIFACT: reearth-web_${{ inputs.new_tag }}.tar.gz
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
       - name: Fetch reearth-web release
         uses: dsaltares/fetch-gh-release-asset@master
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ jobs:
       web: ${{ steps.web.outputs.any_modified }}
       server: ${{ steps.server.outputs.any_modified }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -55,6 +59,10 @@ jobs:
       - ci-server
     if: ${{ !failure() }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
       - run: echo OK
 
   build-prepare:
@@ -79,6 +87,10 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
       - run: echo "OK"
 
   build-server:

--- a/.github/workflows/ci_server.yml
+++ b/.github/workflows/ci_server.yml
@@ -9,6 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'v')
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
       - name: checkout
         uses: actions/checkout@v4
       - name: set up
@@ -41,6 +45,10 @@ jobs:
         ports:
           - 27017:27017
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
       - name: checkout
         uses: actions/checkout@v4
       - name: set up

--- a/.github/workflows/ci_web.yml
+++ b/.github/workflows/ci_web.yml
@@ -15,6 +15,10 @@ jobs:
       run:
         working-directory: web
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/deploy_server_nightly.yml
+++ b/.github/workflows/deploy_server_nightly.yml
@@ -13,6 +13,10 @@ jobs:
       contents: read
       id-token: write
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v4
       - uses: google-github-actions/auth@v2
         with:

--- a/.github/workflows/deploy_web_nightly.yml
+++ b/.github/workflows/deploy_web_nightly.yml
@@ -13,6 +13,10 @@ jobs:
       contents: read
       id-token: write
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v4
       - uses: google-github-actions/auth@v2
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,6 +16,10 @@ jobs:
   pr_title:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
       - uses: actions/labeler@v4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -35,4 +39,8 @@ jobs:
   assign-author:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
       - uses: toshimaru/auto-author-assign@v2.1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/release'
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
       - uses: actions/create-github-app-token@v1
         id: app-token
         with:

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -6,6 +6,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
       - uses: actions/create-github-app-token@v1
         id: app-token
         with:


### PR DESCRIPTION
## Summary

- Add step-security/harden-runner v2.16.1 as the first step in all GitHub Actions workflow jobs
- Configured with egress-policy: audit to monitor outbound traffic
- Improves supply chain security for CI/CD pipelines

## References

- [StepSecurity Harden Runner](https://github.com/step-security/harden-runner)