### PR TITLE
chore: add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,24 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: reearth-marketplace
+  namespace: reearth
+  description: Community plugin marketplace for Re:Earth Visualizer (early stage /
+    stub)
+  annotations:
+    github.com/project-slug: reearth/reearth-marketplace
+  links:
+  - url: https://github.com/reearth/reearth-marketplace
+    title: GitHub
+    icon: github
+  - url: https://marketplace.reearth.io
+    title: Production
+    icon: web
+  tags:
+  - typescript
+  - marketplace
+  - stub
+spec:
+  type: service
+  lifecycle: production
+  owner: reearth/visualizer


### PR DESCRIPTION
Registers this repo in Eukarya's internal developer portal (Backstage). Backstage auto-discovers this file from the default branch once merged.

- **Component:** `reearth-marketplace` (namespace `reearth`)
- **Owner:** `reearth/visualizer`
- **Type / lifecycle:** `service` / `production`

Owner and type were inferred from GitHub team ownership and repo metadata — please edit `spec.owner` / `spec.type` in the file if they're off.

Part of the org-wide Backstage catalog rollout.