### PR TITLE
fix(server): reuse GCS client instead of creating one per request [SCA-01]

### DIFF
--- a/server/internal/app/repo.go
+++ b/server/internal/app/repo.go
@@ -33,7 +33,7 @@ func initReposAndGateways(ctx context.Context, conf *Config, debug bool) (*repo.
 	}
 
 	// File (GCS)
-	fileRepo, err := gcs.NewFile(conf.GCS.Bucket, conf.GCS.AssetsBucket, conf.GCS.AssetsBaseURL)
+	fileRepo, err := gcs.NewFile(ctx, conf.GCS.Bucket, conf.GCS.AssetsBucket, conf.GCS.AssetsBaseURL)
 	if err != nil {
 		log.Fatalf("file: init error: %v", err)
 	}

--- a/server/internal/infrastructure/gcs/file.go
+++ b/server/internal/infrastructure/gcs/file.go
@@ -21,19 +21,25 @@ const (
 )
 
 type fileRepo struct {
+	client           *storage.Client
 	pluginBucketName string
 	assetsBucketName string
 	assetsBaseURL    string
 }
 
-func NewFile(bucketName, assetsBucketName, assetsBaseURL string) (gateway.File, error) {
+func NewFile(ctx context.Context, bucketName, assetsBucketName, assetsBaseURL string) (gateway.File, error) {
 	if bucketName == "" {
 		return nil, errors.New("bucket name is empty")
 	}
 	if assetsBucketName == "" {
 		return nil, errors.New("assets bucket name is empty")
 	}
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		return nil, err
+	}
 	return &fileRepo{
+		client:           client,
 		pluginBucketName: bucketName,
 		assetsBucketName: assetsBucketName,
 		assetsBaseURL:    assetsBaseURL,
@@ -41,11 +47,7 @@ func NewFile(bucketName, assetsBucketName, assetsBaseURL string) (gateway.File, 
 }
 
 func (f *fileRepo) UploadPlugin(ctx context.Context, vid id.VersionID, content []byte) error {
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		return err
-	}
-	bucket := client.Bucket(f.pluginBucketName)
+	bucket := f.client.Bucket(f.pluginBucketName)
 	name := path.Join(gcsPluginBasePath, vid.String(), "plugin.zip")
 	object := bucket.Object(name)
 	if err := object.Delete(ctx); err != nil && !errors.Is(err, storage.ErrObjectNotExist) {
@@ -63,11 +65,7 @@ func (f *fileRepo) UploadPlugin(ctx context.Context, vid id.VersionID, content [
 }
 
 func (f *fileRepo) DownloadPlugin(ctx context.Context, vid id.VersionID) (io.ReadCloser, error) {
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		return nil, err
-	}
-	bucket := client.Bucket(f.pluginBucketName)
+	bucket := f.client.Bucket(f.pluginBucketName)
 	name := path.Join(gcsPluginBasePath, vid.String(), "plugin.zip")
 	object := bucket.Object(name)
 	r, err := object.NewReader(ctx)
@@ -78,11 +76,6 @@ func (f *fileRepo) DownloadPlugin(ctx context.Context, vid id.VersionID) (io.Rea
 }
 
 func (f *fileRepo) UploadImage(ctx context.Context, image io.ReadSeeker) (string, error) {
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		return "", err
-	}
-
 	content, err := io.ReadAll(image) // TODO: size limit
 	if err != nil {
 		return "", err
@@ -93,7 +86,7 @@ func (f *fileRepo) UploadImage(ctx context.Context, image io.ReadSeeker) (string
 		return "", err
 	}
 
-	bucket := client.Bucket(f.assetsBucketName)
+	bucket := f.client.Bucket(f.assetsBucketName)
 
 	digest := sha256.Sum256(content)
 	hexDigest := hex.EncodeToString(digest[:])


### PR DESCRIPTION
## Summary
- `DownloadPlugin`/`UploadPlugin`/`UploadImage` each called `storage.NewClient(ctx)` per invocation and never closed it, leaking connections, an HTTP transport, and a token-refresh goroutine on every call.
- `DownloadPlugin` is the hottest endpoint (`GET /api/plugins/:id/:version`), so sustained traffic accumulated leaked connections/goroutines over time on Cloud Run, risking FD exhaustion/OOM.
- Fix: create a single `*storage.Client` once in `gcs.NewFile` (called at startup with `context.Background()`, matching the existing Mongo client init pattern) and reuse it across all calls — this matches Google's documented guidance that GCS clients "should be reused instead of created as needed" and are safe for concurrent use. Confirmed `reearth-visualizer` already follows this reuse pattern.

Addresses SCA-01 from the recent compliance scan.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/infrastructure/gcs/... ./internal/app/...`
- [x] Manual: run `make run-app` locally and exercise plugin upload/download to confirm behavior is unchanged