### PR TITLE
fix(server): add HTTP client timeouts for repo fetch and OIDC calls [REL-01, REL-02]

### DIFF
--- a/server/internal/infrastructure/mongo/user.go
+++ b/server/internal/infrastructure/mongo/user.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/reearth/reearth-marketplace/server/internal/infrastructure/mongo/mongodoc"
 	"github.com/reearth/reearth-marketplace/server/internal/usecase/repo"
@@ -24,6 +25,10 @@ import (
 type userRepo struct {
 	client *mongox.ClientCollection
 }
+
+// oidcClient bounds calls to the OIDC provider's discovery/userinfo endpoints,
+// reached from the auth middleware's first-login path.
+var oidcClient = &http.Client{Timeout: 30 * time.Second}
 
 func NewUser(client *mongox.Client) repo.User {
 	r := &userRepo{client: client.WithCollection("user")}
@@ -153,7 +158,7 @@ func resolveUserInfoEndpoint(ctx context.Context, iss string) (string, error) {
 		return "", fmt.Errorf("unsupported issuer: %w", err)
 	}
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, configURL, nil)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := oidcClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("get openid-configuration: %w", err)
 	}
@@ -178,7 +183,7 @@ type userInfo struct {
 func fetchUserInfo(ctx context.Context, userInfoEndpoint string, token string) (*userInfo, error) {
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, userInfoEndpoint, nil)
 	req.Header.Set("Authorization", "Bearer "+token)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := oidcClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("get userinfo: %w", err)
 	}

--- a/server/internal/usecase/interactor/plugin.go
+++ b/server/internal/usecase/interactor/plugin.go
@@ -2,8 +2,10 @@ package interactor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"time"
@@ -35,6 +37,31 @@ func NewPlugin(r *repo.Container, gr *gateway.Container) interfaces.Plugin {
 }
 
 var pluginPackageSizeLimit int64 = 10 * 1024 * 1024
+
+// repoFetchClient is hardened for fetching publisher-supplied repo archive URLs.
+// ResponseHeaderTimeout ensures we fail fast if a server is slow to send headers
+// (time-to-first-byte), complementing the overall Client.Timeout which covers
+// the full request lifecycle.
+var repoFetchClient = &http.Client{
+	Timeout: 30 * time.Second,
+	Transport: &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           (&net.Dialer{Timeout: 5 * time.Second, KeepAlive: 30 * time.Second}).DialContext,
+		TLSHandshakeTimeout:   5 * time.Second,
+		ResponseHeaderTimeout: 10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		IdleConnTimeout:       90 * time.Second,
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   10,
+		DisableCompression:    true,
+	},
+	CheckRedirect: func(_ *http.Request, via []*http.Request) error {
+		if len(via) >= 5 {
+			return errors.New("too many redirects")
+		}
+		return nil
+	},
+}
 
 func (p *Plugin) FindByID(ctx context.Context, id id.PluginID, user *id.UserID) (*plugin.VersionedPlugin, error) {
 	pl, err := p.pluginRepo.FindByID(ctx, id, user)
@@ -426,7 +453,7 @@ func (p *Plugin) fetchFromRepo(ctx context.Context, repo *string) (*pluginpack.P
 	}
 
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, ru.ArchiveURL().String(), nil)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := repoFetchClient.Do(req)
 	if err != nil {
 		return nil, interfaces.ErrInvalidPluginPackage
 	}


### PR DESCRIPTION
Replaces http.DefaultClient (no timeout) with bounded clients in fetchFromRepo and the OIDC discovery/userinfo calls, so a slow/non-responding host can't hang the request indefinitely.

Addresses REL-01/REL-02 from the recent compliance scan.