### PR TITLE
fix(server): default DBName to reearth-marketplace

### DIFF
--- a/server/internal/app/config.go
+++ b/server/internal/app/config.go
@@ -15,7 +15,7 @@ const configPrefix = "REEARTH_MARKETPLACE"
 type Config struct {
 	Port     string        `default:"8080" envconfig:"PORT"`
 	DB       string        `default:"mongodb://localhost" pp:"-"`
-	DBName   string        `default:"reearth_marketplace" envconfig:"DB_NAME"`
+	DBName   string        `default:"reearth-marketplace" envconfig:"DB_NAME"`
 	Auth     AuthConfig    `pp:",omitempty"`
 	Auth_M2M AuthM2MConfig `pp:",omitempty"`
 	GCS      GCSConfig     `pp:",omitempty"`


### PR DESCRIPTION
## Summary
- Config.DBName defaulted to reearth_marketplace (underscore), a leftover from an old hardcoded literal.
- The real MongoDB Atlas database is reearth-marketplace (hyphen), matching every other reearth service's naming convention.
- One-line default fix; no other behavior change.