### PR TITLE
ci: grant id-token: write at workflow level

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
     branches: [main, release/*, release]
   pull_request:
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   prepare:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- ci.yml failed with: requesting 'id-token: write', but is only allowed 'id-token: none' (line 125, calling deploy_web_nightly.yml).
- ci.yml had no top-level permissions block, so reusable workflows are capped by the repo's default token permissions instead of what their jobs actually request.
- deploy_web_nightly.yml/deploy_server_nightly.yml jobs need id-token: write for GCP OIDC auth. Adds that at the workflow level.