### PR TITLE
fix(ci): use app token for nightly rc release action

### DIFF
--- a/.github/workflows/build_web.yml
+++ b/.github/workflows/build_web.yml
@@ -152,6 +152,7 @@ jobs:
           tag: ${{ inputs.name }}
           body: ${{ inputs.sha }}
           prerelease: true
+          token: ${{ steps.app-token.outputs.token }}
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- `release-nightly-rc`'s Release step (`ncipollo/release-action@v1`) had no `token:` input, so it silently fell back to the default `GITHUB_TOKEN`, which lacks permission to update an existing release (403: Resource not accessible by integration).
- The job already mints a GitHub App token via `create-github-app-token` (`id: app-token`) but never used it. Wire it into the release step.